### PR TITLE
ref(DateRange): AP/DS - Make start date optional

### DIFF
--- a/src/DateRange.test.ts
+++ b/src/DateRange.test.ts
@@ -8,6 +8,28 @@ describe("DateRange", () => {
   const a = new LocalDate("2000-01-01");
   const b = new LocalDate("2000-01-31");
 
+  const fromYesterdayToYesterday = new DateRange(
+    LocalDate.yesterday(),
+    LocalDate.yesterday()
+  );
+  const fromYesterdayToToday = new DateRange(
+    LocalDate.yesterday(),
+    LocalDate.today()
+  );
+  const fromYesterdayToTomorrow = new DateRange(
+    LocalDate.yesterday(),
+    LocalDate.tomorrow()
+  );
+  const fromTodayToToday = new DateRange(LocalDate.today(), LocalDate.today());
+  const fromTodayToTomorrow = new DateRange(
+    LocalDate.today(),
+    LocalDate.tomorrow()
+  );
+  const fromTomorrowToTomorrow = new DateRange(
+    LocalDate.tomorrow(),
+    LocalDate.tomorrow()
+  );
+
   describe(".constructor", () => {
     it("if called with correct two args, returns date range", () => {
       expect(new DateRange(a, b)).toMatchObject({
@@ -36,106 +58,40 @@ describe("DateRange", () => {
     });
   });
 
-  it(".getCurrentness returns currentness", () => {
-    expect(
-      new DateRange(
-        LocalDate.yesterday(),
-        LocalDate.yesterday()
-      ).getCurrentness()
-    ).toEqual("past");
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.today()).getCurrentness()
-    ).toEqual("current");
-    expect(
-      new DateRange(
-        LocalDate.yesterday(),
-        LocalDate.tomorrow()
-      ).getCurrentness()
-    ).toEqual("current");
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.today()).getCurrentness()
-    ).toEqual("current");
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.tomorrow()).getCurrentness()
-    ).toEqual("current");
-    expect(
-      new DateRange(LocalDate.tomorrow(), LocalDate.tomorrow()).getCurrentness()
-    ).toEqual("future");
+  it(".getCurrentness returns currentness relative to today", () => {
+    expect(fromYesterdayToYesterday.getCurrentness()).toEqual("past");
+    expect(fromYesterdayToToday.getCurrentness()).toEqual("current");
+    expect(fromYesterdayToTomorrow.getCurrentness()).toEqual("current");
+    expect(fromTodayToToday.getCurrentness()).toEqual("current");
+    expect(fromTodayToTomorrow.getCurrentness()).toEqual("current");
+    expect(fromTomorrowToTomorrow.getCurrentness()).toEqual("future");
   });
 
   it(".isBefore returns true if date range is in the past", () => {
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.yesterday()).isBefore()
-    ).toEqual(true);
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.today()).isBefore()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.tomorrow()).isBefore()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.today()).isBefore()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.tomorrow()).isBefore()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.tomorrow(), LocalDate.tomorrow()).isBefore()
-    ).toEqual(false);
+    expect(fromYesterdayToYesterday.isBefore()).toEqual(true);
+    expect(fromYesterdayToToday.isBefore()).toEqual(false);
+    expect(fromYesterdayToTomorrow.isBefore()).toEqual(false);
+    expect(fromTodayToToday.isBefore()).toEqual(false);
+    expect(fromTodayToTomorrow.isBefore()).toEqual(false);
+    expect(fromTomorrowToTomorrow.isBefore()).toEqual(false);
   });
 
   it(".contains returns true if date range is currently ongoing", () => {
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.yesterday()).contains(
-        LocalDate.today()
-      )
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.today()).contains(
-        LocalDate.today()
-      )
-    ).toEqual(true);
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.tomorrow()).contains(
-        LocalDate.today()
-      )
-    ).toEqual(true);
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.today()).contains(
-        LocalDate.today()
-      )
-    ).toEqual(true);
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.tomorrow()).contains(
-        LocalDate.today()
-      )
-    ).toEqual(true);
-    expect(
-      new DateRange(LocalDate.tomorrow(), LocalDate.tomorrow()).contains(
-        LocalDate.today()
-      )
-    ).toEqual(false);
+    expect(fromYesterdayToYesterday.contains(LocalDate.today())).toEqual(false);
+    expect(fromYesterdayToToday.contains(LocalDate.today())).toEqual(true);
+    expect(fromYesterdayToTomorrow.contains(LocalDate.today())).toEqual(true);
+    expect(fromTodayToToday.contains(LocalDate.today())).toEqual(true);
+    expect(fromTodayToTomorrow.contains(LocalDate.today())).toEqual(true);
+    expect(fromTomorrowToTomorrow.contains(LocalDate.today())).toEqual(false);
   });
 
   it(".isAfter returns true if date range is in the past", () => {
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.yesterday()).isAfter()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.today()).isAfter()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.yesterday(), LocalDate.tomorrow()).isAfter()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.today()).isAfter()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.today(), LocalDate.tomorrow()).isAfter()
-    ).toEqual(false);
-    expect(
-      new DateRange(LocalDate.tomorrow(), LocalDate.tomorrow()).isAfter()
-    ).toEqual(true);
+    expect(fromYesterdayToYesterday.isAfter()).toEqual(false);
+    expect(fromYesterdayToToday.isAfter()).toEqual(false);
+    expect(fromYesterdayToTomorrow.isAfter()).toEqual(false);
+    expect(fromTodayToToday.isAfter()).toEqual(false);
+    expect(fromTodayToTomorrow.isAfter()).toEqual(false);
+    expect(fromTomorrowToTomorrow.isAfter()).toEqual(true);
   });
 
   describe(".format", () => {

--- a/src/DateRange.test.ts
+++ b/src/DateRange.test.ts
@@ -30,6 +30,20 @@ describe("DateRange", () => {
     LocalDate.tomorrow()
   );
 
+  const fromInfinityToYesterday = new DateRange(
+    undefined,
+    LocalDate.yesterday()
+  );
+  const fromInfinityToToday = new DateRange(undefined, LocalDate.today());
+  const fromInfinityToTomorrow = new DateRange(undefined, LocalDate.tomorrow());
+
+  const fromYesterdayToInfinity = new DateRange(
+    LocalDate.yesterday(),
+    undefined
+  );
+  const fromTodayToInfinity = new DateRange(LocalDate.today(), undefined);
+  const fromTomorrowToInfinity = new DateRange(LocalDate.tomorrow(), undefined);
+
   describe(".constructor", () => {
     it("if called with correct two args, returns date range", () => {
       expect(new DateRange(a, b)).toMatchObject({
@@ -58,13 +72,21 @@ describe("DateRange", () => {
     });
   });
 
-  it(".getCurrentness returns currentness relative to today", () => {
+  it(".getCurrentness returns currentness", () => {
     expect(fromYesterdayToYesterday.getCurrentness()).toEqual("past");
     expect(fromYesterdayToToday.getCurrentness()).toEqual("current");
     expect(fromYesterdayToTomorrow.getCurrentness()).toEqual("current");
     expect(fromTodayToToday.getCurrentness()).toEqual("current");
     expect(fromTodayToTomorrow.getCurrentness()).toEqual("current");
     expect(fromTomorrowToTomorrow.getCurrentness()).toEqual("future");
+
+    expect(fromInfinityToYesterday.getCurrentness()).toEqual("past");
+    expect(fromInfinityToToday.getCurrentness()).toEqual("current");
+    expect(fromInfinityToTomorrow.getCurrentness()).toEqual("current");
+
+    expect(fromYesterdayToInfinity.getCurrentness()).toEqual("current");
+    expect(fromTodayToInfinity.getCurrentness()).toEqual("current");
+    expect(fromTomorrowToInfinity.getCurrentness()).toEqual("future");
   });
 
   it(".isBefore returns true if date range is in the past", () => {
@@ -74,6 +96,14 @@ describe("DateRange", () => {
     expect(fromTodayToToday.isBefore()).toEqual(false);
     expect(fromTodayToTomorrow.isBefore()).toEqual(false);
     expect(fromTomorrowToTomorrow.isBefore()).toEqual(false);
+
+    expect(fromInfinityToYesterday.isBefore()).toEqual(true);
+    expect(fromInfinityToToday.isBefore()).toEqual(false);
+    expect(fromInfinityToTomorrow.isBefore()).toEqual(false);
+
+    expect(fromYesterdayToInfinity.isBefore()).toEqual(false);
+    expect(fromTodayToInfinity.isBefore()).toEqual(false);
+    expect(fromTomorrowToInfinity.isBefore()).toEqual(false);
   });
 
   it(".contains returns true if date range is currently ongoing", () => {

--- a/src/DateRange.ts
+++ b/src/DateRange.ts
@@ -9,8 +9,15 @@ export class EndDateMustBeOnOrAfterStartDateError extends Error {
 }
 
 export class DateRange {
-  constructor(readonly start: LocalDate, readonly end?: LocalDate) {
-    if (end?.isBefore(start)) {
+  readonly start: LocalDate;
+
+  private readonly startDateProvided: boolean;
+
+  constructor(start?: LocalDate, readonly end?: LocalDate) {
+    this.startDateProvided = !!start;
+    this.start = start ?? LocalDate.MIN_DATE;
+
+    if (end?.isBefore(this.start)) {
       throw new EndDateMustBeOnOrAfterStartDateError();
     }
   }
@@ -68,9 +75,12 @@ export class DateRange {
 
   format({ dateFormat }: { dateFormat?: LocalDateFormat } = {}): string {
     if (this.end) {
-      return `${this.start.format(dateFormat)} – ${this.end.format(
-        dateFormat
-      )}`;
+      if (this.startDateProvided) {
+        return `${this.start.format(dateFormat)} – ${this.end.format(
+          dateFormat
+        )}`;
+      }
+      return `To ${this.end.format(dateFormat)}`;
     }
 
     return `From ${this.start.format(dateFormat)}`;

--- a/src/LocalDate.test.ts
+++ b/src/LocalDate.test.ts
@@ -246,4 +246,38 @@ describe("LocalDate", () => {
       "Apr 01 2021"
     );
   });
+
+  describe("MIN_DATE and MAX_DATE", () => {
+    it("can handle the dates correctly", () => {
+      expect(LocalDate.from("0000-01-01").toString()).toEqual("0000-01-01");
+      expect(LocalDate.from("9999-12-31").toString()).toEqual("9999-12-31");
+
+      expect(LocalDate.from(LocalDate.MIN_DATE).toString()).toEqual(
+        "0000-01-01"
+      );
+      expect(LocalDate.from(LocalDate.MAX_DATE).toString()).toEqual(
+        "9999-12-31"
+      );
+
+      expect(LocalDate.min(LocalDate.MIN_DATE, a)).toEqual(LocalDate.MIN_DATE);
+      expect(LocalDate.min(a, LocalDate.MIN_DATE)).toEqual(LocalDate.MIN_DATE);
+
+      expect(LocalDate.min(LocalDate.MAX_DATE, a)).toEqual(a);
+      expect(LocalDate.min(a, LocalDate.MAX_DATE)).toEqual(a);
+
+      expect(LocalDate.max(LocalDate.MIN_DATE, a)).toEqual(a);
+      expect(LocalDate.max(a, LocalDate.MIN_DATE, a)).toEqual(a);
+
+      expect(LocalDate.max(LocalDate.MAX_DATE, a)).toEqual(LocalDate.MAX_DATE);
+      expect(LocalDate.max(a, LocalDate.MAX_DATE)).toEqual(LocalDate.MAX_DATE);
+
+      expect(LocalDate.MIN_DATE.add(1, "d").toString()).toEqual("0000-01-02");
+      expect(LocalDate.MAX_DATE.subtract(1, "d").toString()).toEqual(
+        "9999-12-30"
+      );
+
+      expect(LocalDate.MIN_DATE.diff(LocalDate.MAX_DATE, "y")).toEqual(-9999);
+      expect(LocalDate.MAX_DATE.diff(LocalDate.MIN_DATE, "y")).toEqual(9999);
+    });
+  });
 });

--- a/src/LocalDate.ts
+++ b/src/LocalDate.ts
@@ -45,6 +45,10 @@ function convertNumberToTwoDigits(number: number): string {
 }
 
 export class LocalDate {
+  static readonly MIN_DATE = new LocalDate("0000-01-01");
+
+  static readonly MAX_DATE = new LocalDate("9999-12-31");
+
   constructor(readonly value: string) {
     if (!/^\d{4}-\d{2}-\d{2}$/.exec(value)) {
       throw new TypeError(`Invalid LocalDate constructor value: ${value}`);


### PR DESCRIPTION
Make start date optional in a backwards compatible way. Start date defaults to `MIN_DATE` if not provided.