### PR TITLE
ci: Handle detached HEAD in buildkite agent

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -18,7 +18,7 @@ echo "--- yarn version-bump"
 yarn version-bump
 
 echo "--- git push"
-git push https://${GITHUB_TOKEN}@github.com/${REPO_ORG}/${REPO_NAME}.git --follow-tags origin master --no-verify
+git push https://${GITHUB_TOKEN}@github.com/${REPO_ORG}/${REPO_NAME}.git --follow-tags origin HEAD:master --no-verify
 
 echo "--- yarn publish"
 yarn publish --non-interactive


### PR DESCRIPTION
Buildkite agent checkouts to a specific commit so it current fails on the `git push` step with error:
```
fatal: refs/remotes/origin/HEAD cannot be resolved to branch.
```