### PR TITLE
ci: Fix `refs/remotes/origin/HEAD cannot be resolved to branch` error

### DIFF
--- a/.buildkite/publish.sh
+++ b/.buildkite/publish.sh
@@ -18,7 +18,7 @@ echo "--- yarn version-bump"
 yarn version-bump
 
 echo "--- git push"
-git push https://${GITHUB_TOKEN}@github.com/${REPO_ORG}/${REPO_NAME}.git --follow-tags origin HEAD:master --no-verify
+git push https://${GITHUB_TOKEN}@github.com/${REPO_ORG}/${REPO_NAME}.git --follow-tags HEAD:master --no-verify
 
 echo "--- yarn publish"
 yarn publish --non-interactive


### PR DESCRIPTION
Was getting this error `refs/remotes/origin/HEAD cannot be resolved to branch` now.

I think this change will work since I tested it with a toy repository though I'm not entirely sure why it's needed.