### PR TITLE
NC-515 Add startOfDay and startOfNextDay methods

### DIFF
--- a/src/LocalDate.test.ts
+++ b/src/LocalDate.test.ts
@@ -397,6 +397,13 @@ describe("LocalDate", () => {
       expect(isMoment(date.startOfNextDay("Australia/Sydney"))).toBeTruthy();
     });
 
+    it("should not mutate the local date", () => {
+      const dateString = "2021-10-01";
+      const date = LocalDate.fromString(dateString);
+      date.startOfDay("Australia/Sydney");
+      expect(date.toString()).toEqual(dateString);
+    });
+
     describe("in the Sydney timezone", () => {
       it("should be the start of the next day during daylight savings", () => {
         const date = LocalDate.fromString("2021-11-02");

--- a/src/LocalDate.test.ts
+++ b/src/LocalDate.test.ts
@@ -1,5 +1,5 @@
 import MockDate from "mockdate";
-import moment from "moment-timezone";
+import moment, { isMoment } from "moment-timezone";
 import { LocalDate, LocalDateFormat } from "./LocalDate";
 
 MockDate.set("2020-09-27T10:00:00");
@@ -355,5 +355,73 @@ describe("LocalDate", () => {
     expect(LocalDate.from("2021-04-01").toDate().toString()).toMatch(
       "Apr 01 2021"
     );
+  });
+
+  describe("startOfDay", () => {
+    it("should return a moment", () => {
+      const date = LocalDate.fromString("2021-10-01");
+      expect(isMoment(date.startOfDay("Australia/Sydney"))).toBeTruthy();
+    });
+
+    describe("in the Sydney timezone", () => {
+      it("should be the start of the day during daylight savings", () => {
+        const date = LocalDate.fromString("2021-11-02");
+        const datetime = date.startOfDay("Australia/Sydney");
+        expect(datetime.toISOString()).toEqual("2021-11-01T13:00:00.000Z");
+      });
+
+      it("should be the start of the day not during daylight savings", () => {
+        const date = LocalDate.fromString("2021-06-02");
+        const datetime = date.startOfDay("Australia/Sydney");
+        expect(datetime.toISOString()).toEqual("2021-06-01T14:00:00.000Z");
+      });
+    });
+
+    it("should handle various timezones", () => {
+      const date = LocalDate.fromString("2021-11-02");
+
+      const datetime1 = date.startOfDay("America/Los_Angeles");
+      expect(datetime1.toISOString()).toEqual("2021-11-02T07:00:00.000Z");
+
+      const datetime2 = date.startOfDay("Europe/Rome");
+      expect(datetime2.toISOString()).toEqual("2021-11-01T23:00:00.000Z");
+
+      const datetime3 = date.startOfDay("Pacific/Auckland");
+      expect(datetime3.toISOString()).toEqual("2021-11-01T11:00:00.000Z");
+    });
+  });
+
+  describe("startOfNextDay", () => {
+    it("should return a moment", () => {
+      const date = LocalDate.fromString("2021-10-01");
+      expect(isMoment(date.startOfNextDay("Australia/Sydney"))).toBeTruthy();
+    });
+
+    describe("in the Sydney timezone", () => {
+      it("should be the start of the next day during daylight savings", () => {
+        const date = LocalDate.fromString("2021-11-02");
+        const datetime = date.startOfNextDay("Australia/Sydney");
+        expect(datetime.toISOString()).toEqual("2021-11-02T13:00:00.000Z");
+      });
+
+      it("should be the start of the next day not during daylight savings", () => {
+        const date = LocalDate.fromString("2021-06-02");
+        const datetime = date.startOfNextDay("Australia/Sydney");
+        expect(datetime.toISOString()).toEqual("2021-06-02T14:00:00.000Z");
+      });
+    });
+
+    it("should handle various timezones", () => {
+      const date = LocalDate.fromString("2021-11-02");
+
+      const datetime1 = date.startOfNextDay("America/Los_Angeles");
+      expect(datetime1.toISOString()).toEqual("2021-11-03T07:00:00.000Z");
+
+      const datetime2 = date.startOfNextDay("Europe/Rome");
+      expect(datetime2.toISOString()).toEqual("2021-11-02T23:00:00.000Z");
+
+      const datetime3 = date.startOfNextDay("Pacific/Auckland");
+      expect(datetime3.toISOString()).toEqual("2021-11-02T11:00:00.000Z");
+    });
   });
 });

--- a/src/LocalDate.ts
+++ b/src/LocalDate.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/prefer-regexp-exec */
-import moment from "moment-timezone";
+import moment, { Moment } from "moment-timezone";
 import { DateTimeWithTimeZone } from "./DateTimeWithTimeZone";
 import { DefaultTimeZoneRef } from "./DefaultTimeZoneRef";
 
@@ -345,6 +345,14 @@ export class LocalDate {
       this.moment.date()
     );
     return date;
+  }
+
+  startOfDay(zoneId: string): Moment {
+    return moment.tz(this.toString(), zoneId);
+  }
+
+  startOfNextDay(zoneId: string): Moment {
+    return moment.tz(this.add(1, "day").toString(), zoneId);
   }
 
   toEqual(other: unknown): boolean {


### PR DESCRIPTION
## Description
Adding startOfDay and startOfNextDay methods to Ailo’s LocalDate. They’ll return the moment that represents midnight at the start/end of the date on which they’re called in the timezone that’s passed.
e.g.
```
LocalDate.fromString("2021-11-02").startOfDay("Australia/Sydney").toISOString() = "2021-11-01T13:00:00.000Z"

LocalDate.fromString("2021-11-02").startOfNextDay("Australia/Sydney").format("YYYY-MM-DD hh:mm:ss") = "2021-11-03 00:00:00"
```

Not using endOfDay because other libraries give a return a millisecond before the end of the day for endOfDay so startOfNextDay is clearer.

## Links 
https://ailohq.slack.com/archives/C02UG6U61/p1635817754110500
https://ailo.atlassian.net/browse/NC-515